### PR TITLE
Staffのqrcodeカラムのnotnull成約削除

### DIFF
--- a/db/migrate/20180720090859_create_staffs.rb
+++ b/db/migrate/20180720090859_create_staffs.rb
@@ -5,7 +5,7 @@ class CreateStaffs < ActiveRecord::Migration[5.1]
       t.string :given_name,       null: false
       t.string :family_name_kana, null: false
       t.string :given_name_kana,  null: false
-      t.string :qrcode,           null: false
+      t.string :qrcode
       t.integer :status,          null: false,  default: 0
       t.integer :store_id,        null: false
       t.integer :work_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 20180720103014) do
     t.string "given_name", null: false
     t.string "family_name_kana", null: false
     t.string "given_name_kana", null: false
-    t.string "qrcode", null: false
+    t.string "qrcode"
     t.integer "status", default: 0, null: false
     t.integer "store_id", null: false
     t.integer "work_id"


### PR DESCRIPTION
staff新規追加にて
次の画面に遷移してqrcodeを作成するため、qrcodeカラムがnotnull成約が入っていると保存が出来ない。