### PR TITLE
モバイルでアクセス時にモバイル用のQR読取り画面へ遷移機能実装

### DIFF
--- a/app/views/cameras/show.html.erb
+++ b/app/views/cameras/show.html.erb
@@ -1,5 +1,5 @@
 <!-- instascan PC用 -->
-<h1 class="text-center">QRコードをかざして下さい</h1>
+<h1 class="text-center">QRコードをかざして下さい(PC用)</h1>
 <div class="container">
   <div class="row justify-content-center">
     <!-- ここにカメラの映像を表示する -->
@@ -14,6 +14,13 @@
 
 <!-- <script src="instascan.min.js"></script> -->
 <script>
+  //PC以外ならモバイル用のQR看取り画面へジャンプ
+  var ua = navigator.userAgent;
+  var redirectPass = 'cameras/index';
+  if(ua.search(/iPhone/) != -1 || ua.search(/iPad/) != -1 || ua.search(/iPod/) != -1 || ua.search(/Android/) != -1){
+      location.href = redirectPass;
+  }//ここまで
+
   var videoTag = document.getElementById('preview');
   var info = document.getElementById('info');
   var scanner = new Instascan.Scanner({ video: videoTag });


### PR DESCRIPTION
cameras/showのinstascanがモバイルで反応が悪いため、jsQRを使用しているcameras/indexページへモバイルでアクセス時に自動でジャンプする機能実装